### PR TITLE
docs: 完善 README 使用指南

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,23 +18,97 @@
 
 ---
 
+## ⚙️ 环境要求
+
+- Node.js ≥ 18.17（Next.js 14 需要的最低版本）
+- pnpm ≥ 8.15（monorepo 依赖管理）
+- Python ≥ 3.10（FastAPI 后端）
+- 推荐在 macOS / Linux 下使用，Windows 用户可通过 WSL2 体验
+
 ## 🚀 快速开始
 
+1. **安装 Node.js 依赖**
+
+   ```bash
+   pnpm install
+   ```
+
+   该命令会在整个 workspace 中安装/联结前端、CLI、代码生成等包。
+
+2. **准备 Python 虚拟环境并安装依赖**
+
+   ```bash
+   cd services/api
+   python -m venv .venv
+   source .venv/bin/activate  # Windows 使用 .venv\Scripts\activate
+   pip install -e .[dev]
+   ```
+
+   如需更改上传文件存储目录或跨域设置，可在根目录创建 `.env` 并配置 `PROTOWEAVER_STORAGE_DIR`、`PROTOWEAVER_CORS_ORIGINS` 等变量。
+
+3. **启动 FastAPI 后端**
+
+   ```bash
+   uvicorn app.main:app --reload --port 8000
+   ```
+
+   默认提供 `/healthz` 健康检查以及 `/v1/projects` 系列接口，上传的草图/语音会保存在 `services/api/uploads/`。
+
+4. **启动 Studio 前端工作台**
+
+   ```bash
+   pnpm -C apps/studio dev
+   ```
+
+   - 默认监听 `http://localhost:3000`，通过 `NEXT_PUBLIC_API_BASE` 环境变量指定后端地址。
+   - 界面包含“上传草图与语音 → UI-IR 预览 → 代码预览 → 对话式迭代”四个区域：
+     1. 上传 PNG/JPG 草图、可选 WAV/M4A 语音，或直接粘贴语音转写文本跳过 ASR。
+     2. 生成后实时显示 UI-IR JSON，便于调试或导出。
+     3. 同步展示生成的 Next.js + Tailwind 代码，可在标签页中切换不同文件。
+     4. 输入自然语言指令，调用 `/iterate` 接口生成新版本并查看交互历史。
+
+5. **（可选）启动 Preview 预览器**
+
+   ```bash
+   pnpm -C apps/preview dev
+   ```
+
+   该预览器基于 Vite + React，默认渲染 `@protoweaver/ui-ir` 中的示例数据。若需查看实际生成结果，可在浏览器控制台执行：
+
+   ```js
+   localStorage.setItem('protoweaver-ui-ir', JSON.stringify(actualUIIR))
+   ```
+
+6. **（可选）运行示例 Worker**
+
+   ```bash
+   cd services/worker
+   python -m protoweaver_worker.worker
+   ```
+
+   Worker 以异步任务形式模拟 CV / ASR / LLM 推理流程，便于日后替换为真实队列服务。
+
+完成以上步骤后，即可在浏览器访问 [http://localhost:3000](http://localhost:3000/) 上传草图与语音并进行对话式迭代。预览器默认读取 `localStorage` 中的 `protoweaver-ui-ir`。
+
+## 🧰 命令行工具
+
+CLI 基于 `@protoweaver/cli`，适合批量处理或集成到 CI/CD。
+
 ```bash
-# 安装依赖
-pnpm install
+# 构建 CLI（第一次使用或修改后执行）
+pnpm --filter @protoweaver/cli build
 
-# 启动后端 (FastAPI)
-uvicorn services.api.app.main:app --reload
+# 生成原型：上传草图与可选语音，输出 UI-IR + 代码
+pnpm exec protoweaver generate --sketch path/to/sketch.png --audio path/to/intent.m4a --out out/
 
-# 启动前端工作台
-pnpm -C apps/studio dev
+# 导出内置 Demo UI-IR
+pnpm exec protoweaver sample --out tmp/
 
-# 可选：启动预览器 (Vite)
-pnpm -C apps/preview dev
+# 对既有项目进行自然语言迭代
+pnpm exec protoweaver patch --id <projectId> --message "把 CTA 改成立即体验"
 ```
 
-访问 [http://localhost:3000](http://localhost:3000/) 上传草图与语音。预览器默认读取 `localStorage` 中的 `protoweaver-ui-ir`。
+通过设置 `PROTOWEAVER_API_URL` 可切换后端地址，例如调用远程部署的 API。
 
 ---
 
@@ -62,7 +136,15 @@ protoweaver/
 ## 🧪 测试
 
 - TypeScript 包：`pnpm -r test`
-- Python API：`pytest`（位于 `services/api`）
+- Lint / Format：`pnpm -r lint`、`pnpm -r format`
+- Python API：`cd services/api && pytest`
+- 一键执行：`make test` 会同时运行 JS/TS 测试与 `pytest`
+
+## 📚 数据与示例
+
+- `data/samples/`：草图、语音与 UI-IR 的占位示例，可按需替换为公开数据集以验证流程。
+- `services/api/uploads/`：后端运行时的临时上传目录，可通过 `PROTOWEAVER_STORAGE_DIR` 自定义。
+- `docs/`：补充的架构与流程说明文档。
 
 ---
 


### PR DESCRIPTION
## Summary
- 增补运行 ProtoWeaver 所需的 Node.js、pnpm 与 Python 环境要求
- 提供后端、Studio、预览器与示例 Worker 的启动步骤及界面操作指引
- 新增 CLI 用法、测试命令及数据目录说明，帮助用户完整体验项目

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d118a5b860832aa58ab1de317b7f01